### PR TITLE
Add button to close prop modal on mobile

### DIFF
--- a/frontend/components/Modal/modal.tsx
+++ b/frontend/components/Modal/modal.tsx
@@ -44,12 +44,21 @@ const Modal: React.FC<IModalProps> = ({
       {/* The backdrop, rendered as a fixed sibling to the panel container */}
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
+      
+
       {/* This is the actual modal and it's contents */}
       <div className="fixed inset-0 overflow-y-auto">
         <div className="flex min-h-full items-center justify-center">
           <Dialog.Panel className="w-full max-w-5xl bg-white ">
             <div className="">
               <div className="px-4 py-3 md:px-12 md:py-10">
+              
+                <div className="flex justify-end sm:hidden">
+                  <button className="w-fit border font-bold bg-black border-black text-white rounded-full px-1.5" onClick={handleClose as any}>
+                  X
+                  </button>
+                </div>
+                
                 <ReactMarkdown className={styles.markdown}>
                   {description}
                 </ReactMarkdown>


### PR DESCRIPTION
### Before 
Whenever I open a prop on mobile it takes up the entire view, therefore I can't get out of it to go and read another prop. On desktop, I know you can just click outside of the modal to close it, but there's no spare room "outside" the modal to click. Also, since we don't change paths I can't just hit "Back" so I'm stuck and have to refresh the page.
<img src="https://user-images.githubusercontent.com/26611339/206884389-335f66c1-4831-43c6-945c-fd15439f0f7c.jpeg" width="250">

### After
By adding an "**x**" button on mobile, we can close the modal and avoid a "dead end."
![ezgif com-gif-maker (14)](https://user-images.githubusercontent.com/26611339/206884431-224d5eac-60ad-4288-8fb3-00e4ec745e7d.gif)
